### PR TITLE
Fixing object#clone, npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "coffee -o lib/ -c src/*.*coffee",
-    "test": "coffee ./test.coffee",
+    "test": "coffee --nodejs --harmony test/test.litcoffee",
     "watch": "coffee --nodejs --harmony -o lib/ -cw src/*.*coffee"
   },
   "repository": {

--- a/src/object.litcoffee
+++ b/src/object.litcoffee
@@ -44,7 +44,7 @@ Perform a deep clone on an object. Taken from [The CoffeeScript Cookboox][0].
           return object
 
         if object instanceof Date
-          return new Date(obj.getTime())
+          return new Date(object.getTime())
 
         if object instanceof RegExp
           flags = ''
@@ -54,15 +54,28 @@ Perform a deep clone on an object. Taken from [The CoffeeScript Cookboox][0].
           flags += 'y' if object.sticky?
           return new RegExp(object.source, flags)
 
-        clone = new object.constructor()
+        _clone = new object.constructor()
 
         for key of object
-          clone[key] = ($.clone object[key])
+          _clone[key] = (clone object[key])
 
-        return clone
+        return _clone
 
-      context.test "clone"
+      context.test "clone", ->
+        is_clone = (original, copy) ->
+          assert.notEqual  original, copy
+          assert.deepEqual original, copy
 
+        person =
+          name: "Steve Jobs"
+          address:
+            street: "1 Infinite Loop"
+            city: "Cupertino, CA"
+            zip: 95014
+          birthdate: new Date 'Feb 24, 1955'
+          regex: /foo.*/igm
+
+        is_clone person, clone person
 
 ## property
 


### PR DESCRIPTION
This fixes #26, and another error on line 47 that was referring to the wrong variable name. In addition, the `npm test` command now works as expected.

Test included.
